### PR TITLE
add: azuread provider to grab AKS enabled RBAC spn id

### DIFF
--- a/aks-tf-examples/kubelogin/providers.tf
+++ b/aks-tf-examples/kubelogin/providers.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>3.0"
     }
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "2.39.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~>3.0"


### PR DESCRIPTION
Preparing to fix issue with using kubelogin get-token command to grab proper k8s auth token with cluster.  The SPN for the --server-id value is not the same as the --client-id (var.client_id)