### PR TITLE
fix: the ID value is the SPN that validates RBAC calls

### DIFF
--- a/aks-tf-examples/kubelogin/main.tf
+++ b/aks-tf-examples/kubelogin/main.tf
@@ -1,3 +1,8 @@
+# Get the SPN for RBAC enabled AKS Clusters in this Tenant
+data "azuread_service_principal" "aks" {
+  display_name = "Azure Kubernetes Service AAD Server"
+}
+
 # Generate random resource group name
 resource "random_pet" "rg_name" {
   prefix = var.resource_group_name_prefix
@@ -74,7 +79,7 @@ provider "kubernetes" {
       "--tenant-id",
       var.tenant_id,
       "--server-id",
-      var.client_id,
+      data.azuread_service_principal.aks.application_id,
       "--client-id",
       var.client_id,
       "--client-secret",


### PR DESCRIPTION
Related to adding the azuread provider.  This will help fix issue with using kubelogin get-token command to grab proper k8s auth token with cluster.  The SPN for the --server-id value is not the same as the --client-id (var.client_id)