### PR TITLE
fix: this is required for RBAC and Kubelogin

### DIFF
--- a/aks-tf-examples/kubelogin/main.tf
+++ b/aks-tf-examples/kubelogin/main.tf
@@ -26,8 +26,9 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   local_account_disabled = true
 
   azure_active_directory_role_based_access_control {
-  managed = true
-  admin_group_object_ids = var.admin_group_object_ids
+    managed = true
+    admin_group_object_ids = var.admin_group_object_ids
+    azure_rbac_enabled = true
   }
 
   identity {


### PR DESCRIPTION
related to the other changes to fix kubelogin get-token exec plugin