### PR TITLE
update: pin k8s deployment to suffixed version

### DIFF
--- a/aks-tf-examples/kubelogin/main.tf
+++ b/aks-tf-examples/kubelogin/main.tf
@@ -71,7 +71,7 @@ provider "kubernetes" {
   }
 }
 
-resource "kubernetes_deployment" "nginx" {
+resource "kubernetes_deployment_v1" "nginx" {
   provider = kubernetes
   metadata {
     name = "scalable-nginx-example"


### PR DESCRIPTION
Kubernetes provider will be deprecating non-versioned suffix resources in the future (e.g. ```kuberenetes_deployment```) in favor of being able to pin to api versions (e.g. ```_v1```).  This will help to avoid any deprecated breaking changes for this demo to have a bit more longevity.